### PR TITLE
Clarify Signal ID input step

### DIFF
--- a/ArduinoSignals/Credentials.h
+++ b/ArduinoSignals/Credentials.h
@@ -18,9 +18,9 @@ limitations under the License.
 const String SSID = "YOUR_WIFI_NETWORK"; 
 const String Password = "YOUR_WIFI_PASSWORD";
 
-/* Your Signal ID should be lowercase, and each word is separated by dashes. 
-If Google Assistant spoke too quickly, you can ask to repeat the identifier 
-at any time be saying "What is the identifier for [SIGNAL NAME]?" */
+/* Your Signal ID should be lowercase, and each word should be separated by dashes. 
+If Google Assistant spoke too quickly, you can ask to repeat the identifier at any 
+time be saying "What is the setup code for [SIGNAL NAME]?" */
 const String SignalID = "your-signal-id";
 
 /* Enter the below API keys to track the weather on Umbrella Signal and Pants Signal. */

--- a/ArduinoSignals/Credentials.h
+++ b/ArduinoSignals/Credentials.h
@@ -18,7 +18,10 @@ limitations under the License.
 const String SSID = "YOUR_WIFI_NETWORK"; 
 const String Password = "YOUR_WIFI_PASSWORD";
 
-const String SignalID = "YOUR-SIGNAL-ID";
+/* Your Signal ID should be lowercase, and each word is separated by dashes. 
+If Google Assistant spoke too quickly, you can ask to repeat the identifier 
+at any time be saying "What is the identifier for [SIGNAL NAME]?" */
+const String SignalID = "your-signal-id";
 
 /* Enter the below API keys to track the weather on Umbrella Signal and Pants Signal. */
 const String DarkSkyAPIKey = "YOUR_DARK_SKY_API_KEY";


### PR DESCRIPTION
Responding to @tomvdb from #5 to clarify the signal id input step. Also added a comment explaining how to re-request the signal ID from the google assistant conversation, since it is sometimes tough to catch the ID on the first pass on the Google Home. 