### PR TITLE
Change Celebrate to StretchBreak in Arduino files

### DIFF
--- a/ArduinoSignals/APICalls.cpp
+++ b/ArduinoSignals/APICalls.cpp
@@ -272,11 +272,11 @@ void PaperSignals::CryptoCurrencyExecution(String JSONData)
 
 }
 
-void PaperSignals::CelebrateExecution(String JSONData)
+void PaperSignals::StretchBreakExecution(String JSONData)
 {
-  DynamicJsonBuffer celebrateBuffer;
-  JsonObject& celebrateRoot = celebrateBuffer.parseObject(JSONData);
-  breakTimeInterval = celebrateRoot["parameters"]["duration"]["amount"]; // In Minutes
+  DynamicJsonBuffer stretchBreakBuffer;
+  JsonObject& stretchBreakRoot = stretchBreakBuffer.parseObject(JSONData);
+  breakTimeInterval = stretchBreakRoot["parameters"]["duration"]["amount"]; // In Minutes
   breakTimeInterval = breakTimeInterval*60*1000;
 
   if(lastBreakTime > millis()) // Reset every 49 days
@@ -295,13 +295,13 @@ void PaperSignals::CelebrateExecution(String JSONData)
   {
     // Hands Up
     Serial.println("Break Time");
-    MoveServoToPosition(CELEBRATE_TIME_REACHED, 10);
+    MoveServoToPosition(STRETCHBREAK_TIME_REACHED, 10);
   }
   else
   {
     // Hands Down
     Serial.println("No Breaks Yet");
-    MoveServoToPosition(CELEBRATE_NOT_YET, 10);
+    MoveServoToPosition(STRETCHBREAK_NOT_YET, 10);
   }
 
 }
@@ -687,9 +687,9 @@ void PaperSignals::ParseIntentName(String intentName, String JSONData)
     {
       TimerExecution(JSONData);
     }
-    else if(intentName == CelebrateType)
+    else if(intentName == StretchBreakType)
     {
-      CelebrateExecution(JSONData);
+      StretchBreakExecution(JSONData);
     }
     else if(intentName == RocketLaunchType)
     {

--- a/ArduinoSignals/APICalls.h
+++ b/ArduinoSignals/APICalls.h
@@ -81,7 +81,7 @@ public:
 	String ShortsOrPantsType = "ShortsOrPants";
 	String UmbrellaType = "Umbrella";
 	String TimerType = "Timer";
-	String StretchBreak = "StretchBreak";
+	String StretchBreakType = "StretchBreak";
 	String RocketLaunchType = "RocketLaunch";
 	String CountdownType = "Countdown";
 	String TestSignalType = "TestSignal";

--- a/ArduinoSignals/APICalls.h
+++ b/ArduinoSignals/APICalls.h
@@ -55,8 +55,8 @@ limitations under the License.
 #define ROCKET_NOT_LAUNCHED 65
 
 // Celebrate
-#define CELEBRATE_TIME_REACHED 0
-#define CELEBRATE_NOT_YET 90
+#define STRETCHBREAK_TIME_REACHED 0
+#define STRETCHBREAK_NOT_YET 90
 
 // Test Signal
 #define TEST_FIRST_POSITION 10
@@ -81,7 +81,7 @@ public:
 	String ShortsOrPantsType = "ShortsOrPants";
 	String UmbrellaType = "Umbrella";
 	String TimerType = "Timer";
-	String CelebrateType = "StretchBreak";
+	String StretchBreak = "StretchBreak";
 	String RocketLaunchType = "RocketLaunch";
 	String CountdownType = "Countdown";
 	String TestSignalType = "TestSignal";


### PR DESCRIPTION
Renaming functions, variables, and enums referencing 'celebrate' to 'stretchBreak' for consistency with the newly released Stretch Signal. This PR changes no functionality. 