### PR TITLE
Fix Stretch Break Header File

### DIFF
--- a/ArduinoSignals/APICalls.h
+++ b/ArduinoSignals/APICalls.h
@@ -114,7 +114,7 @@ public:
 	void CryptoCurrencyExecution(String JSONData);
 	void ShortsOrPantsExecution(String JSONData);
 	void UmbrellaExecution(String JSONData);
-	void CelebrateExecution(String JSONData);
+	void StretchBreakExecution(String JSONData);
 	void RocketExecution(String JSONData);
 	void TestSignalExecution(String JSONData);
 	void StockExecution(String JSONData);


### PR DESCRIPTION
APICalls.h needed to be changed because the prototype for StretchBreak wasn't defined.

I'm guessing the commit for this was just missed in the initial PR.