### PR TITLE
Use inSeconds value rather than Amount

### DIFF
--- a/ArduinoSignals/APICalls.cpp
+++ b/ArduinoSignals/APICalls.cpp
@@ -145,7 +145,7 @@ void PaperSignals::TimerExecution(String JSONData)
 {
   DynamicJsonBuffer jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(JSONData);
-  int seconds = root["parameters"]["duration"]["amount"];
+  int seconds = root["parameters"]["duration"]["inSeconds"];
 
   Serial.print("Timer: ");
   Serial.println(seconds);


### PR DESCRIPTION
Changes the timer / countdown signal to use the inSeconds value from Firebase instead of the duration value it was using before.