### PR TITLE
APICalls: fix time include name for linux

### DIFF
--- a/ArduinoSignals/APICalls.h
+++ b/ArduinoSignals/APICalls.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <WiFiClientSecure.h>
 #include <ESP8266HTTPClient.h>
 #include <Servo.h>
-#include <Time.h>
+#include <time.h>
 #include "Credentials.h"
 
 #define SERVO_PIN 14


### PR DESCRIPTION
In the esp8266 2.4.0 core the filename for `time.h` is lowercase, without that the compilation fail when using arduino on linux.

```
./packages/esp8266/hardware/esp8266/2.4.0/tools/sdk/libc/xtensa-lx106-elf/include/time.h
```